### PR TITLE
Use valve_id for water control commands to support pressure pump

### DIFF
--- a/src/gardena/devices/water_control.py
+++ b/src/gardena/devices/water_control.py
@@ -30,7 +30,7 @@ class WaterControl(BaseDevice):
             "type": "VALVE_CONTROL",
             "attributes": {"command": "START_SECONDS_TO_OVERRIDE", "seconds": duration},
         }
-        self.smart_system.call_smart_system_service(self.id, data)
+        self.smart_system.call_smart_system_service(self.valve_id, data)
 
     def stop_until_next_task(self):
         data = {
@@ -38,7 +38,7 @@ class WaterControl(BaseDevice):
             "type": "VALVE_CONTROL",
             "attributes": {"command": "STOP_UNTIL_NEXT_TASK"},
         }
-        self.smart_system.call_smart_system_service(self.id, data)
+        self.smart_system.call_smart_system_service(self.valve_id, data)
 
     def pause(self):
         data = {
@@ -46,7 +46,7 @@ class WaterControl(BaseDevice):
             "type": "VALVE_CONTROL",
             "attributes": {"command": "PAUSE"},
         }
-        self.smart_system.call_smart_system_service(self.id, data)
+        self.smart_system.call_smart_system_service(self.valve_id, data)
 
     def unpause(self):
         data = {
@@ -54,4 +54,4 @@ class WaterControl(BaseDevice):
             "type": "VALVE_CONTROL",
             "attributes": {"command": "UNPAUSE"},
         }
-        self.smart_system.call_smart_system_service(self.id, data)
+        self.smart_system.call_smart_system_service(self.valve_id, data)


### PR DESCRIPTION
In order to use the api for the pressure pump, the valve_id has to be used for valve commands.
It is untested, if this affects the gardena water control.

This pull request fixes #15.