### PR TITLE
Remove shebang

### DIFF
--- a/src/gardena/__init__.py
+++ b/src/gardena/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
This is a module and not a command-line tool thus the shebang is not needed.