### PR TITLE
Add exception when status code is 401

### DIFF
--- a/src/gardena/exceptions/authentication_exception.py
+++ b/src/gardena/exceptions/authentication_exception.py
@@ -1,0 +1,2 @@
+class AuthenticationException(Exception):
+    pass


### PR DESCRIPTION
A specific exception is now raised when the API sends an http status 401.
This is to be able to have a specific log to tell the user to renew his token.