### PR TITLE
Fix start_ws never ending after quit

### DIFF
--- a/src/gardena/smart_system.py
+++ b/src/gardena/smart_system.py
@@ -235,6 +235,7 @@ class SmartSystem:
                 continue
             self.logger.debug("Message received ..")
             self.on_message(message)
+        await websocket.close()
 
     def on_message(self, message):
         data = json.loads(message)

--- a/src/gardena/smart_system.py
+++ b/src/gardena/smart_system.py
@@ -229,7 +229,10 @@ class SmartSystem:
         self.logger.debug("Connected !")
         while not self.should_stop:
             self.logger.debug("Waiting for message ..")
-            message = await websocket.recv()
+            try:
+                message = await asyncio.wait_for(websocket.recv(), timeout=1)
+            except asyncio.TimeoutError:
+                continue
             self.logger.debug("Message received ..")
             self.on_message(message)
 


### PR DESCRIPTION
Once start_ws is started, __launch_websocket_loop does:
 - connect to Gardena websocket API
 - while not should_stop
   - await reception of a message
   - process message

The problem is that "websocket.recv" is blocking and then even if should_stop change to true, nothing happen.

I've then implemented a asyncio wait_for in order to timeout the recv function.
this way, the should_stop is evaluated regularly and if smart_system.quit is executed, the start_ws stop gracefully 1 sec later.

(safe to do so as mentioned in websockets doc : https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#websockets.client.WebSocketClientProtocol.recv)

In addition, I've also closed the websocket, otherwise some asyncio Task are still running.
This avoids some errors like "Task was destroyed but it is pending!"

This way, all Tasks are well closed.

If you need an example code to highlight the problem, feel free to ask
