### PR TITLE
oauthlib is sill part of py-smart-gardena requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     url="https://github.com/grm/py-smart-gardena",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
-    install_requires=["requests", "websockets", "httpx", "authlib", "backoff"],
+    install_requires=["requests", "websockets", "httpx", "oauthlib", "authlib", "backoff"],
     setup_requires=["pytest-runner"],
     tests_require=tests_require,
     extras_require={"dev": ["pre-commit"]},


### PR DESCRIPTION
Hi,

I tried to install and use py-smart-gardena in a fresh new env (I'm using devcontainers).

And then, if I try to import SmartSystem, I receive this error message : 

> Exception has occurred: ModuleNotFoundError
No module named 'oauthlib'
  File "/app/gardena2mqtt.py", line 8, in <module>
    from gardena.smart_system import SmartSystem
ModuleNotFoundError: No module named 'oauthlib'

I assume that is because it is missing in setup.py

thanks