### PR TITLE
change token revoke route

### DIFF
--- a/src/gardena/smart_system.py
+++ b/src/gardena/smart_system.py
@@ -86,9 +86,10 @@ class SmartSystem:
         self.should_stop = True
         if self.client:
             if self.token_manager.access_token:
-                await self.client.delete(
-                    f"{self.AUTHENTICATION_HOST}/v1/token/{self.token_manager.access_token}",
-                    headers={"X-Api-Key": self.client_id},
+                await self.client.post(
+                    f"{self.AUTHENTICATION_HOST}/v1/oauth2/revoke",
+                    headers={"Authorization": "Bearer " + self.token_manager.access_token},
+                    data={"token": self.token_manager.access_token}
                 )
 
     async def token_saver(self, token, refresh_token=None, access_token=None):


### PR DESCRIPTION
DELETE route is obsolete and Gardena added a POST /revoke route


![image](https://github.com/user-attachments/assets/80b0484d-e721-4c51-bfaa-7785686d1ea9)